### PR TITLE
Downgraded numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-numpy = "^1.24.2"
+numpy = "^1.23.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Downgraded numpy version from `1.24.2` to `1.23.0` because of numba incompatibility issues

Fixes #5 